### PR TITLE
Add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.gitignore'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.gitignore'
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    # Only run on main branch push, not on PRs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            pab1it0/chess-mcp:latest
+            pab1it0/chess-mcp:${{ github.sha }}
+          cache-from: type=registry,ref=pab1it0/chess-mcp:latest
+          cache-to: type=inline
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically build and publish Docker images to Docker Hub after successful merges to the main branch.

## Features
- Automatically builds and pushes the Docker image to Docker Hub when code changes are merged to the main branch
- Ignores non-code changes like documentation updates to avoid unnecessary rebuilds
- Tags images with both `latest` and the commit SHA for versioning
- Uses Docker Buildx for multi-platform builds (amd64 and arm64)
- Implements caching to speed up build times

## Setup Required
To use this workflow, you'll need to add the following secrets to your GitHub repository:
- `DOCKERHUB_USERNAME`: Your Docker Hub username
- `DOCKERHUB_TOKEN`: A Docker Hub access token with permissions to push to the repository

This workflow will ensure that your Docker image on Docker Hub (`pab1it0/chess-mcp`) is always up to date with the latest code changes.