### PR TITLE
Update Dockerfile to connect repository to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY pyproject.toml /app/
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH="/app"
+    PYTHONPATH="/app" \
+    PYTHONFAULTHANDLER=1
 
 USER app
 
@@ -39,9 +40,13 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 CMD ["/app/.venv/bin/chess-mcp"]
 
+# GitHub Container Registry Metadata
 LABEL org.opencontainers.image.title="Chess.com API MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Chess.com API integration" \
       org.opencontainers.image.version="0.1.0" \
       org.opencontainers.image.authors="Pavel Shklovsky" \
-      org.opencontainers.image.source="https://github.com/Pavel.Shklovsky/chess-mcp" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.source="https://github.com/pab1it0/chess-mcp" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.url="https://github.com/pab1it0/chess-mcp" \
+      org.opencontainers.image.documentation="https://github.com/pab1it0/chess-mcp#readme" \
+      org.opencontainers.image.vendor="Pavel Shklovsky"


### PR DESCRIPTION
This PR updates the Dockerfile to properly connect the repository to the container image according to GitHub's recommended practices.

## Changes

- Updated the `org.opencontainers.image.source` label to point to the correct repository URL (`https://github.com/pab1it0/chess-mcp`)
- Added additional metadata labels to improve package discoverability and connection to the repository:
  - `org.opencontainers.image.url`: Links to the repository homepage
  - `org.opencontainers.image.documentation`: Points to the README file
  - `org.opencontainers.image.vendor`: Identifies the package maintainer

These changes follow the guidelines in the [GitHub documentation for connecting a repository to a container image](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line).

The improved metadata will help users find and understand the connection between the container image and its source repository, and also allows GitHub to better associate the package with its repository.