### PR TITLE
Add demo video to static directory and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A [Model Context Protocol][mcp] (MCP) server for Chess.com's Published Data API.
 
 This provides access to Chess.com player data, game records, and other public information through standardized MCP interfaces, allowing AI assistants to search and analyze chess information.
 
+![Chess MCP Demo](./static/chess-mcp.mp4)
+
 [mcp]: https://modelcontextprotocol.io
 
 ## Features


### PR DESCRIPTION
This PR adds a demo video to the repository in a dedicated static directory and displays it in the README.md file right after the description section.

The video is placed in the `/static` directory for better organization and future scalability of static assets.

The demo video provides a visual demonstration of the Chess MCP functionality.