### PR TITLE
Add Docker installation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The list of tools is configurable, so you can choose which tools you want to mak
 
 ### Docker (Recommended)
 
-The easiest way to run chess-mcp with [Claude Desktop](https://claude.ai/desktop) is using Docker.
+The easiest way to run chess-mcp with [Claude Desktop](https://claude.ai/desktop) is using Docker. If you don't have Docker installed, you can get it from [Docker's official website](https://www.docker.com/get-started/).
+
 
 Edit your Claude Desktop config file:
 * Mac: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
This PR adds a link to Docker's official website in the README, making it easier for users to install Docker if they don't already have it.

The link directs users to Docker's "Get Started" page where they can download and install Docker for their operating system.