### PR TITLE
Fix: Suppress initial non-JSON output on stdout

### DIFF
--- a/src/chess_mcp/main.py
+++ b/src/chess_mcp/main.py
@@ -3,10 +3,10 @@ import sys
 from chess_mcp.server import mcp, config
 
 def setup_environment():
-    print("Using environment variables for configuration")
+    # print("Using environment variables for configuration")
 
-    print(f"Chess.com API configuration:")
-    print(f"  Base URL: {config.base_url}")
+    #print(f"Chess.com API configuration:")
+     # print(f"  Base URL: {config.base_url}")
     
     return True
 
@@ -15,8 +15,8 @@ def run_server():
     if not setup_environment():
         sys.exit(1)
     
-    print("\nStarting Chess.com MCP Server...")
-    print("Running server in standard mode...")
+    # print("\nStarting Chess.com MCP Server...")
+    # print("Running server in standard mode...")
     
     # Run the server with the stdio transport
     mcp.run(transport="stdio")

--- a/src/chess_mcp/main.py
+++ b/src/chess_mcp/main.py
@@ -5,8 +5,8 @@ from chess_mcp.server import mcp, config
 def setup_environment():
     # print("Using environment variables for configuration")
 
-    #print(f"Chess.com API configuration:")
-     # print(f"  Base URL: {config.base_url}")
+    # print(f"Chess.com API configuration:")
+    # print(f"  Base URL: {config.base_url}")
     
     return True
 


### PR DESCRIPTION
Hey, I love this MCP and I hope this would improve my chess playing.

Anyway, I had problems to let it works in Claude Desktop. I was running the Docker version. I resolved cloning the repo and commenting the print() statements in main.py.

Here is a complete description.

### Problem:
The chess-mcp server currently prints several non-JSON informational messages to standard output during startup (e.g., "Using environment variables...", "Chess.com API configuration...", "Starting Chess.com MCP Server..."). Clients that communicate with the MCP server via standard input/output and expect pure JSON-RPC messages (such as Claude Desktop, where I called the server via docker) encounter JSON parsing errors when receiving this initial non-JSON output.

### Solution:
This pull request comments (and disables) the print() statements in src/chess_mcp/main.py that output these initial informational messages to standard output.

### Impact:
By suppressing this non-JSON output on stdout, the server's output stream becomes purely JSON-RPC from the beginning of the communication, allowing clients that strictly parse standard output as JSON to connect and interact with the server without errors. This improves compatibility with such clients.