### PR TITLE
chore: bump minor version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-06-01
+
+### Changed
+- Removed all print statements and comments from Python files
+- Cleaned up codebase for better maintainability
+
 ## [0.1.0] - 2025-03-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chess_mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for Chess.com API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/chess_mcp/__init__.py
+++ b/src/chess_mcp/__init__.py
@@ -5,4 +5,4 @@ A Model Context Protocol server implementation that provides tools and resources
 for interacting with the Chess.com Published Data API.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
Bumped minor version from 0.1.0 to 0.2.0

## Changes
- Updated version in `pyproject.toml`
- Updated version in `src/chess_mcp/__init__.py`
- Added new changelog entry for v0.2.0