### PR TITLE
Add versioning to CI pipeline

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,8 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
     paths-ignore:
       - '**.md'
       - '.github/ISSUE_TEMPLATE/**'
@@ -18,30 +20,70 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    # Only run on main branch push, not on PRs
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            pab1it0/chess-mcp
+            ghcr.io/pab1it0/chess-mcp
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=Chess.com API MCP Server
+            org.opencontainers.image.description=Model Context Protocol server for Chess.com API integration
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: |
-            pab1it0/chess-mcp:latest
-            pab1it0/chess-mcp:${{ github.sha }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           cache-from: type=registry,ref=pab1it0/chess-mcp:latest
           cache-to: type=inline
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+      - name: Sign artifacts with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: ./dist/*.tar.gz ./dist/*.whl
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*
+            dist/*.sigstore.json
+
+      - name: Publish to MCP Registry
+        uses: pab1it0/mcp-publish-action@v1
+        with:
+          server-json-path: ./server.json

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,0 +1,59 @@
+name: Sync Version
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'pyproject.toml'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Update server.json
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          # Update top-level version field and package image
+          jq --arg version "$VERSION" '.version = $version | .package.image = "ghcr.io/pab1it0/chess-mcp:" + $version' server.json > server.json.tmp
+          mv server.json.tmp server.json
+          echo "Updated server.json with version $VERSION"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          git diff --exit-code server.json || echo "changes=true" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changes == 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add server.json
+          git commit -m "chore: sync version to ${{ steps.get_version.outputs.version }}"
+          git push

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,22 +4,24 @@ on:
   push:
     branches: [main]
     tags:
-      - "v*"
+      - 'v*'
   pull_request:
     branches: [main]
 
 jobs:
-  ci:
+  test:
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.12'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -43,6 +45,25 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Build package
-        run: |
-          uv build
+        run: uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG VERSION=0.1.0
+
 FROM python:3.12-slim-bookworm AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -14,6 +16,8 @@ RUN uv venv && \
     uv pip install -e .
 
 FROM python:3.12-slim-bookworm
+
+ARG VERSION=0.1.0
 
 WORKDIR /app
 
@@ -40,13 +44,17 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
 
 CMD ["/app/.venv/bin/chess-mcp"]
 
-# GitHub Container Registry Metadata
+# OCI Image Labels
 LABEL org.opencontainers.image.title="Chess.com API MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for Chess.com API integration" \
-      org.opencontainers.image.version="0.1.0" \
+      org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.authors="Pavel Shklovsky" \
       org.opencontainers.image.source="https://github.com/pab1it0/chess-mcp" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.url="https://github.com/pab1it0/chess-mcp" \
       org.opencontainers.image.documentation="https://github.com/pab1it0/chess-mcp#readme" \
-      org.opencontainers.image.vendor="Pavel Shklovsky"
+      org.opencontainers.image.vendor="Pavel Shklovsky" \
+      io.modelcontextprotocol.server.name="io.github.pab1it0/chess-mcp" \
+      mcp.server.transport.stdio="true" \
+      mcp.server.category="data-retrieval" \
+      mcp.server.tags="chess,chess.com,games,api,player-stats"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://modelcontextprotocol.io/schema/2025-10-17/server.json",
+  "name": "io.github.pab1it0/chess-mcp",
+  "version": "0.1.0",
+  "description": "MCP server providing Chess.com player data, game records, and other public information through standardized MCP interfaces",
+  "package": {
+    "type": "oci",
+    "image": "ghcr.io/pab1it0/chess-mcp:0.1.0",
+    "transport": "stdio"
+  },
+  "config": {
+    "env": {}
+  },
+  "repository": "https://github.com/pab1it0/chess-mcp",
+  "website": "https://github.com/pab1it0/chess-mcp"
+}


### PR DESCRIPTION
Comprehensive CI/CD refactoring to support semantic versioning, automated releases, and MCP registry deployment:

- Add semantic versioning to Docker images based on git tags (semver with v prefix)
- Configure multi-registry publishing (Docker Hub + GitHub Container Registry)
- Add dynamic VERSION build argument to Dockerfile
- Enhance OCI image labels with MCP-specific metadata
- Add io.modelcontextprotocol.server.name label
- Add mcp.server.transport.stdio, mcp.server.category, and mcp.server.tags labels
- Create automated release workflow for tag pushes
- Implement PyPI publishing with Sigstore artifact signing
- Add GitHub Release automation with release notes
- Configure MCP Registry deployment integration
- Create server.json for MCP registry metadata
- Add sync-version.yml workflow to maintain version consistency
- Refactor CI workflow with separate test and build jobs
- Enable multi-platform Docker builds (linux/amd64, linux/arm64)

This aligns the project with prometheus-mcp-server standards for enterprise-grade CI/CD practices.