### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ https://github.com/user-attachments/assets/3b33361b-b604-465c-9f6a-3699b6907757
 
 The list of tools is configurable, so you can choose which tools you want to make available to the MCP client.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/pab1ito-chess-mcp).
+
 ## Usage
 
 ### Docker (Recommended)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/pab1ito-chess-mcp).